### PR TITLE
Added the precision option to the writer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -262,9 +262,9 @@ class Client {
    * @param  {String} precision timestamp precision for all points
    * @return {Writer}        [description]
    */
-  write(measurement, precision = 'n') {
+  write(measurement) {
     const internalData = internal(this);
-    const writer = new Writer(internalData.influx, internalData.writeQueue, precision);
+    const writer = new Writer(internalData.influx, internalData.writeQueue);
     writer.measurement = measurement;
     return writer;
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -259,13 +259,14 @@ class Client {
   /**
    * write write point to measurement
    * @param  {String} measurement measurement名称
-   * @param  {String} precision timestamp precision for all points
+   * @param  {String} precision timestamp precision for all points OPTIONAL
    * @return {Writer}        [description]
    */
-  write(measurement) {
+  write(measurement, precision) {
     const internalData = internal(this);
     const writer = new Writer(internalData.influx, internalData.writeQueue);
     writer.measurement = measurement;
+    writer.precision = precision;
     return writer;
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -259,11 +259,12 @@ class Client {
   /**
    * write write point to measurement
    * @param  {String} measurement measurement名称
+   * @param  {String} precision timestamp precision for all points
    * @return {Writer}        [description]
    */
-  write(measurement) {
+  write(measurement, precision = 'n') {
     const internalData = internal(this);
-    const writer = new Writer(internalData.influx, internalData.writeQueue);
+    const writer = new Writer(internalData.influx, internalData.writeQueue, precision);
     writer.measurement = measurement;
     return writer;
   }

--- a/lib/influx.js
+++ b/lib/influx.js
@@ -121,6 +121,9 @@ class Influx {
       queryData.u = opts.username;
       queryData.p = opts.password;
     }
+    if (points[0].precision) {
+      queryData.precision = points[0].precision;
+    }
     const postData = _.map(points, getPostData);
     return client.post('/write', postData.join('\n'), queryData).then(res => res.body, err => {
       /* istanbul ignore next */

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -11,7 +11,7 @@ class Writer {
    * @param  {[type]} queueSet [Set instance for queue]
    * @return {[type]}          [description]
    */
-  constructor(client, queueSet, precision) {
+  constructor(client, queueSet) {
     const internalData = internal(this);
     internalData.client = client;
     internalData.queueSet = queueSet;
@@ -19,7 +19,7 @@ class Writer {
     internalData.tags = {};
     internalData.fields = {};
     internalData.time = 0;
-    internalData.precision = precision;
+    internalData.precision = undefined;
   }
   /**
    * [measurement description]

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -11,7 +11,7 @@ class Writer {
    * @param  {[type]} queueSet [Set instance for queue]
    * @return {[type]}          [description]
    */
-  constructor(client, queueSet) {
+  constructor(client, queueSet, precision) {
     const internalData = internal(this);
     internalData.client = client;
     internalData.queueSet = queueSet;
@@ -19,6 +19,7 @@ class Writer {
     internalData.tags = {};
     internalData.fields = {};
     internalData.time = 0;
+    internalData.precision = precision;
   }
   /**
    * [measurement description]
@@ -34,6 +35,21 @@ class Writer {
    */
   get measurement() {
     return internal(this).measurement;
+  }
+  /**
+   * [measurement description]
+   * @param  {[type]} v [description]
+   * @return {[type]}   [description]
+   */
+  set precision(v) {
+    internal(this).precision = v;
+  }
+  /**
+   * [measurement description]
+   * @return {[type]} [description]
+   */
+  get precision() {
+    return internal(this).precision;
   }
   /**
    * [tag add tags to the point]
@@ -99,7 +115,8 @@ class Writer {
     if (!internalData.time) {
       this.time();
     }
-    const data = _.pick(internalData, 'measurement tags fields time'.split(' '));
+
+    const data = _.pick(internalData, 'measurement tags fields time precision'.split(' '));
     /* istanbul ignore if */
     if (!data.measurement) {
       throw new Error('measurement can not be null');

--- a/test/writer.js
+++ b/test/writer.js
@@ -77,6 +77,29 @@ describe('Writer', () => {
       }).catch(done);
   });
 
+  it('write point with time and precision', done => {
+    const writer = new Writer(influx);
+    writer.measurement = 'http';
+    writer.precision = 'ms';
+    writer.tag('usePrecision', 'true')
+      .field('use', 100)
+      .time(1463413422809)
+      .then(() => {
+        return delay(100);
+      })
+      .then(() => {
+        const reader = new Reader(influx);
+        reader.measurement = 'http';
+        // return reader.tag({spdy: '  lightning'});
+        return reader.condition('usePrecision', 'true');
+      })
+      .then(data => {
+        assert.equal(data.results[0].series[0].values.length, 1);
+	assert.equal(new Date(data.results[0].series[0].values[0][0]).getTime(), 1463413422809);
+        done();
+      }).catch(done);
+  });
+
   it('write queue', done => {
     const set = new Set();
     const writer = new Writer(influx, set);

--- a/test/writer.js
+++ b/test/writer.js
@@ -80,7 +80,9 @@ describe('Writer', () => {
   it('write point with time and precision', done => {
     const writer = new Writer(influx);
     writer.measurement = 'http';
+    assert.equal(writer.precision, undefined);
     writer.precision = 'ms';
+    assert.equal(writer.precision, 'ms');
     writer.tag('usePrecision', 'true')
       .field('use', 100)
       .time(1463413422809)


### PR DESCRIPTION
As mentioned in #4 I added a way to set the precision.
I changed the interface a bit, so you can set the precision through the client.

`client.write('test', 'ms')...`
Maybe this interface should change.