### PR TITLE
Changes to time handling as discussed in #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ write point to the influxdb's measurement
 
 - `tags` tag set, optional
 
+- `precision` timestamp precision. ['n','u','ms','s','m','h'], optional
 
 ```js
 const Influx = require('influxdb-nodejs');
@@ -213,7 +214,7 @@ client.writePoint('http', {
 }, {
   status: '40x',
   size: '1K'
-});
+}, 'ms');
 ```
 
 
@@ -225,11 +226,12 @@ write point to the influxdb's measurement, return Writer instance
 
 - `measurement` write point to the measurement
 
+- `precision` timestamp precision. ['n','u','ms','s','m','h'], optional
 
 ```js
 const Influx = require('influxdb-nodejs');
 const client = new Influx('http://127.0.0.1:8086/mydb');
-const writer = client.write('http');
+const writer = client.write('http', 's');
 ```
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -246,10 +246,12 @@ class Client {
    * @param  {[type]} measurement [description]
    * @param  {[type]} fields      [description]
    * @param  {[type]} tags        [description]
+   * @param  {string} precision   The timestamp precision. 'h', 'm', 's', 'ms',
+   *                              'u', 'n' OPTIONAL
    * @return {[type]}             [description]
    */
-  writePoint(measurement, fields, tags) {
-    const writer = this.write(measurement);
+  writePoint(measurement, fields, tags, precision) {
+    const writer = this.write(measurement, precision);
     writer.field(fields);
     if (tags) {
       writer.tag(tags);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,12 +1,6 @@
 'use strict';
 const _ = require('lodash');
 
-function now() {
-  const ms = Date.now();
-  const us = `${Math.ceil(process.hrtime()[1] / 1000)}`;
-  return `${ms}${_.padStart(us, '6', '0')}`;
-}
-
 function getError(err) {
   const str = _.get(err, 'response.body.error');
   /* istanbul ignore if */
@@ -61,7 +55,6 @@ function toCsv(data) {
   return result;
 }
 
-exports.now = now;
 exports.getError = getError;
 exports.toJSON = toJSON;
 exports.toCsv = toCsv;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const internal = require('./internal');
 const debug = require('./debug');
-const util = require('./util');
 
 class Writer {
   /**
@@ -87,7 +86,7 @@ class Writer {
    * @return {[type]}   [description]
    */
   time(v) {
-    internal(this).time = `${v || util.now()}`;
+    internal(this).time = v;
     return this;
   }
   /**
@@ -112,9 +111,6 @@ class Writer {
    */
   toJSON() {
     const internalData = internal(this);
-    if (!internalData.time) {
-      this.time();
-    }
 
     const data = _.pick(internalData, 'measurement tags fields time precision'.split(' '));
     /* istanbul ignore if */
@@ -135,9 +131,6 @@ class Writer {
       throw new Error('queue set is undefined');
     }
     /* istanbul ignore else */
-    if (!internal(this).time) {
-      this.time();
-    }
     queueSet.add(this.toJSON());
     return this;
   }

--- a/test/client.js
+++ b/test/client.js
@@ -69,6 +69,21 @@ describe('Client:singleton', () => {
     }).catch(done);
   });
 
+  it('write point with precision', done => {
+    client.writePoint('http', {
+      use: 404,
+    }, {
+      spdy: 'faster',
+    }, 'ms')
+    .then(data => {
+      return client.query('http')
+        .condition('spdy', 'faster');
+    }).then(data => {
+      assert.equal(data.results[0].series[0].values[0][4], 'faster');
+      done();
+    }).catch(done);
+  });
+
   it('sync write queue', done => {
     client.syncWrite().then(data => {
       done();

--- a/test/util.js
+++ b/test/util.js
@@ -3,12 +3,6 @@ const _ = require('lodash');
 const assert = require('assert');
 const util = require('../lib/util');
 describe('util', () => {
-  it('now', () => {
-    const now = util.now();
-    assert(_.isString(now));
-    assert.equal(now.length, 19);
-  });
-
   it('get error', () => {
     const e = new Error('400');
     e.response = {

--- a/test/writer.js
+++ b/test/writer.js
@@ -57,11 +57,14 @@ describe('Writer', () => {
   });
 
   it('write point with time', done => {
+    const ms = Date.now();
+    const us = `${Math.ceil(process.hrtime()[1] / 1000)}`;
+    const ns = `${ms}${_.padStart(us, '6', '0')}`;
     const writer = new Writer(influx);
     writer.measurement = 'http';
     writer.tag('spdy', 'lightning')
       .field('use', 100)
-      .time()
+      .time(ns)
       .then(() => {
         return delay(100);
       })
@@ -113,7 +116,6 @@ describe('Writer', () => {
       assert.equal(item.measurement, 'http');
       assert.equal(item.tags.spdy, 'fast');
       assert.equal(item.fields.use, 200);
-      assert.equal(item.time.length, 19);
     }
     assert.equal(set.size, 1);
     done();


### PR DESCRIPTION
As discussed in #4 you can now set the timestamp precision in `client.writePoint()`.
I documented the changes in the README.

Also the time handling is changed. The node client will no longer set the timestamp to the current server time. The time has to be set explicitly or influxdb will use the timestamp at insert time.