### PR TITLE
Fixing bug so strings can end in i

### DIFF
--- a/lib/influx.js
+++ b/lib/influx.js
@@ -7,7 +7,7 @@ const internal = require('./internal');
 const debug = require('./debug');
 const util = require('./util');
 
-const influxInt = new RegExp("^[0-9]+i$");
+const influxInt = new RegExp('^[0-9]+i$');
 
 function convert(v) {
   if (!_.isString(v)) {

--- a/lib/influx.js
+++ b/lib/influx.js
@@ -7,6 +7,8 @@ const internal = require('./internal');
 const debug = require('./debug');
 const util = require('./util');
 
+const influxInt = new RegExp("^[0-9]+i$");
+
 function convert(v) {
   if (!_.isString(v)) {
     return v;
@@ -25,7 +27,7 @@ function isBoolean(v) {
 
 function formatFields(data) {
   return _.map(data, (v, k) => {
-    if (_.isString(v) && v.charAt(v.length - 1) !== 'i' && !isBoolean(v)) {
+    if (_.isString(v) && !influxInt.test(v) && !isBoolean(v)) {
       return `${convert(k)}="${v}"`;
     }
     return `${convert(k)}=${convert(v)}`;


### PR DESCRIPTION
Strings that end in i were getting caught in the check, replacing with a regexp check that requires all preceding values to be a digit.

Ref: #14 