### PR TITLE
update 'clinet : client' typo in docs

### DIFF
--- a/docs/Client.html
+++ b/docs/Client.html
@@ -553,7 +553,7 @@ console.info(client.format);
 
     <h5>Example</h5>
     
-    <pre class="prettyprint"><code>const formatType = clinet.format;
+    <pre class="prettyprint"><code>const formatType = client.format;
 console.info(formatType);
 // => undefined</code></pre>
 
@@ -632,7 +632,7 @@ console.info(formatType);
 client.query('login')
  .set({limit: 1})
  .queue();
-console.info(clinet.queryQueueLength);
+console.info(client.queryQueueLength);
 // => 2</code></pre>
 
 
@@ -943,7 +943,7 @@ client.write('http')
    use: 1000,
  })
  .queue();
-console.info(clinet.writeQueueLength);
+console.info(client.writeQueueLength);
 // => 2</code></pre>
 
 
@@ -2732,12 +2732,12 @@ console.on('queryQueue', (data) => {
 
     <h5>Examples</h5>
     
-    <pre class="prettyprint"><code>const clinet = new Influx('http://127.0.0.1:8086/mydb')
+    <pre class="prettyprint"><code>const client = new Influx('http://127.0.0.1:8086/mydb')
 client.queryRaw('select * from "http"')
   .then(console.info)
   .catch(console.error);</code></pre>
 
-    <pre class="prettyprint"><code>const clinet = new Influx('http://127.0.0.1:8086/mydb')
+    <pre class="prettyprint"><code>const client = new Influx('http://127.0.0.1:8086/mydb')
 client.queryRaw('select * from "login"', 'testdb')
   .then(console.info)
   .catch(console.error);</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
 <a href="https://coveralls.io/r/vicanso/influxdb-nodejs?branch=master"><img src="https://img.shields.io/coveralls/vicanso/influxdb-nodejs/master.svg?style=flat" alt="Coverage Status"></a>
 <a href="https://www.npmjs.org/package/influxdb-nodejs"><img src="http://img.shields.io/npm/v/influxdb-nodejs.svg?style=flat-square" alt="npm"></a>
 <a href="https://github.com/vicanso/influxdb-nodejs"><img src="https://img.shields.io/npm/dm/influxdb-nodejs.svg?style=flat-square" alt="Github Releases"></a></p>
-<p>A simple clinet for influxdb, including these features:</p>
+<p>A simple client for influxdb, including these features:</p>
 <ul>
 <li><p>Writing multiple points</p>
 </li>
@@ -71,7 +71,7 @@
 </ul>
 <h2>Installation</h2><pre class="prettyprint source lang-js"><code>$ npm install influxdb-nodejs</code></pre><h2>Examples</h2><p>Writing multiple points and set schema for measurment</p>
 <pre class="prettyprint source lang-js"><code>const Influx = require('influxdb-nodejs');
-const clinet = new Influx('http://127.0.0.1:8086/mydb');
+const client = new Influx('http://127.0.0.1:8086/mydb');
 const fieldSchema = {
   use: 'integer',
   bytes: 'integer',

--- a/docs/lib_client.js.html
+++ b/docs/lib_client.js.html
@@ -285,7 +285,7 @@ class Client extends EventEmitter {
    * @return {String}
    * @since 2.2.0
    * @example
-   * const formatType = clinet.format;
+   * const formatType = client.format;
    * console.info(formatType);
    * // => undefined
    */
@@ -354,7 +354,7 @@ class Client extends EventEmitter {
    *    use: 1000,
    *  })
    *  .queue();
-   * console.info(clinet.writeQueueLength);
+   * console.info(client.writeQueueLength);
    * // => 2
    */
   get writeQueueLength() {
@@ -372,7 +372,7 @@ class Client extends EventEmitter {
    * client.query('login')
    *  .set({limit: 1})
    *  .queue();
-   * console.info(clinet.queryQueueLength);
+   * console.info(client.queryQueueLength);
    * // => 2
    */
   get queryQueueLength() {
@@ -776,13 +776,13 @@ class Client extends EventEmitter {
    * @return {Promise}
    * @since 2.2.0
    * @example
-   * const clinet = new Influx('http://127.0.0.1:8086/mydb')
+   * const client = new Influx('http://127.0.0.1:8086/mydb')
    * client.queryRaw('select * from "http"')
    *   .then(console.info)
    *   .catch(console.error);
    *
    * @example
-   * const clinet = new Influx('http://127.0.0.1:8086/mydb')
+   * const client = new Influx('http://127.0.0.1:8086/mydb')
    * client.queryRaw('select * from "login"', 'testdb')
    *   .then(console.info)
    *   .catch(console.error);


### PR DESCRIPTION
Noticed client variable was misspelled a few times throughout documentation as _clinet_